### PR TITLE
Company change Honeywell -> Quantinuum

### DIFF
--- a/Project_Organization.md
+++ b/Project_Organization.md
@@ -19,8 +19,8 @@ regulatory guidelines. Projects are otherwise independent.
 Steering Members are organizations that sign a legal agreement capturing the
 ideas summarized in the documents on this repository. They may participate in
 each Working Group and the Steering Committee. The Steering Member designates an
-individual to represent the organization in Steering Committee meetings. 
-The current Steering Committee votes on accepting new Steering Members 
+individual to represent the organization in Steering Committee meetings.
+The current Steering Committee votes on accepting new Steering Members
 taking the following factors into consideration, among other aspects:
 
 - Organization has demonstrated a sustained interest and commitment in

--- a/profile/README.md
+++ b/profile/README.md
@@ -19,7 +19,7 @@ Alliance](https://github.com/qir-alliance/.github/blob/main/.images/header2.png)
 
 ### Steering Committee
 
-Steering members include Honeywell, Microsoft, Oak Ridge National Laboratory,
+Steering members include Microsoft, Oak Ridge National Laboratory, Quantinuum,
 Quantum Circuits Inc., and Rigetti Computing (in alphabetical order). For more
 information about the project organization, we refer to [this
 document](https://github.com/qir-alliance/.github/blob/main/Project_Organization.md).


### PR DESCRIPTION
@rtvuser1 @1tnguyen @kalzoo The combination of Cambridge Quantum Computing and Honeywell Quantum Solutions is executed: https://www.quantinuum.com/
Alex has signed the steering member agreement on behalf of the new company. As soon as the existing steering committee approves, I can countersigns and we can update all documents accordingly.