### PR TITLE
Meeting minutes and Base Profile workstream definition update

### DIFF
--- a/minutes/sc-meeting-2022-02.md
+++ b/minutes/sc-meeting-2022-02.md
@@ -1,0 +1,55 @@
+# Steering Committee Meeting February 2022
+
+Attendance: Alex Chernoguzov, Alex Mccaskey, Andrei Petrenko, Bettina Heim,
+Dmitry Liakh, Tom Lubinski, Wim Lavrijsen
+
+## Meeting agenda
+
+- Recap and status
+- SC meeting attendees Quantinuum
+- Workstream: Base Profile
+- Workstream: entry point handling and runtime initialization/finalization
+- Next steps
+
+## Recap and status
+
+- NWQSim repo is ready to be create/migrated
+- Workstream template and the draft for the Base Profile definition have been
+  added to the org repo
+- QIR community calls have gathered some interest and will continue at a
+  bi-weekly schedule
+
+## Key decisions (all voted unanimously, one voting member absent)
+
+- Ross Duncan to be added to the SC meeting invite
+- Base Profile workstream approved, pending updating the workstream definition
+  to clarify the discussed points captured on the [GitHub
+  issue](https://github.com/qir-alliance/.github/issues/15)
+
+## Follow-ups / Action items
+
+- Bettina to create repo for NWQSim
+- Bettina to update meeting minutes and update the Base Profile workstream
+  definition based on discussions
+- Alex C. and Tom to approve the PR on behalf of the steering committee to
+  officially launch the first workstream
+- Alex M. to
+  - create a PR with the workstream definition for entry point handling and
+    runtime initialization/finalization
+  - drive discussions about and updates of the workstream definition
+  - call for a vote asynchronously with at least seven days of notice once/if
+    discussions have come to a conclusion before the next SC meeting
+- Investigations around CLA bots are in progress
+
+## Additional notes
+
+- Discussions around the Base Profile workstream definition have been captured
+  in this [GitHub issue](https://github.com/qir-alliance/.github/issues/15)
+- The entry point handling and runtime initialization/finalization workstream
+  definition as well as discussion topics that came up during the SC meeting are
+  captured in this [GitHub
+  issue](https://github.com/qir-alliance/.github/issues/16)
+- Upon launching a workstream, a chair should be designated by the working
+  group. The chair is responsible for organizing the working group and meetings,
+  and for tracking the ongoing work. For each meeting, an agenda should be
+  defined and shared ahead of time.

--- a/profile/README.md
+++ b/profile/README.md
@@ -26,6 +26,14 @@ to the corresponding workstream definition for more information about how to get
 involved. Alternatively, please reach out to
 [qiralliance@mail.com](mailto:qiralliance@mail.com).
 
+The following workstreams have been approved by the steering committee and are
+currently actively worked on:
+
+- Specification of a Base Profile that defines the minimal requirements to
+  define and execute quantum programs <br/> [[workstream
+  definition](https://github.com/qir-alliance/.github/blob/main/workstreams/Base_Profile_Workstream.md),
+  [GitHub issue](https://github.com/qir-alliance/qir-spec/issues/7)]
+
 If you would like to suggest a new workstream, please take a look at the
 [workstream creation
 template](https://github.com/qir-alliance/.github/blob/main/workstreams/Workstream_Creation_Template.md),
@@ -33,10 +41,10 @@ and reach out to [qiralliance@mail.com](mailto:qiralliance@mail.com) with your
 suggestion. Currently, creation of the following workstreams are being
 discussed:
 
-- Specification of a Base Profile that defines the minimal requirements to
-  define and execute quantum programs <br/> [[workstream
-  definition](https://github.com/qir-alliance/.github/blob/main/workstreams/Base_Profile_Workstream.md),
-  [GitHub issue](https://github.com/qir-alliance/.github/issues/15)]
+- Update the QIR specification to clarify mechanisms for entry point handling,
+  including command line input as well as runtime initialization and
+  finalization <br/>
+  [[GitHub issue](https://github.com/qir-alliance/.github/issues/16) ]
 
 ### Steering Committee
 
@@ -121,10 +129,9 @@ Alliance](https://github.com/qir-alliance/.github/blob/main/.images/header2.png)
 ### Inquiries and Community Forums
 
 For any inquiries about the QIR Alliance, our work and upcoming opportunities,
-please contact [qiralliance@mail.com](mailto:qiralliance@mail.com).
-
-If you are curious about our work, the following community forums may be of
-interest for you:
+please contact [qiralliance@mail.com](mailto:qiralliance@mail.com). If you are
+curious about our work, the following community forums may be of interest for
+you:
 
 - [QIR
   channel](https://discord.com/channels/764231928676089909/920935966586306631)

--- a/workstreams/Base_Profile_Workstream.md
+++ b/workstreams/Base_Profile_Workstream.md
@@ -12,10 +12,9 @@ progress through that will be useful to consumers of the specification.
 ## Requirements
 
 The Base Profile should specify the minimal requirements to support defining and
-executing quantum programs for gate-based quantum processors. In addition to a
-set of LLVM instructions, the Base Profile may rely on a quantum instruction set
-define separately, but should not make use of any runtime functions listed in
-the QIR specification.
+executing quantum programs. In addition to a set of LLVM instructions, the Base
+Profile may rely on a quantum instruction set define separately, but should not
+make use of any runtime functions listed in the QIR specification.
 
 The profile should specify all permitted LLVM instructions, and define all
 required constructs for the program to be valid and executable on targeted
@@ -54,61 +53,134 @@ A](https://github.com/qir-alliance/qir-spec/blob/main/specification/v0.1/7_Profi
 on the [specification repository](https://github.com/qir-alliance/qir-spec).
 
 In addition to the Base Profile itself, one or more quantum instruction set(s)
-should be defined to provide the means to manipulate the quantum state, and at
-least one defined quantum instruction set should permit universal quantum
-computations. The quantum instruction set(s) specified as part of this
-workstream should meet the requirements specified by the Base Profile.
-Conversely, the Base Profile should not rely on any particular quantum
-instruction(s) being available.
+should be defined to provide the means to manipulate the quantum state. The
+quantum instruction set(s) specified as part of this workstream should meet the
+requirements specified by the Base Profile. Conversely, the Base Profile should
+not rely on any particular quantum instruction(s) being available.
+
+To targeted a quantum program to a specific backend requires selecting a
+suitable profile and a compatible quantum instruction set. The profile and the
+quantum instruction set (QIS) selection together fully determine how the program
+IR should be represented. In addition to defining the Base Profile itself and at
+least one compatible QIS, this workstream will also add a section to the
+specification that contains guidance for defining and documenting addition
+quantum instruction sets going forward.
 
 A template for a specification definition can be found
 [here](https://github.com/CommunitySpecification/1.0/blob/master/7._CS_Template.md).
 This may serve as inspiration but it is not required to follow the template
 precisely.
 
-## Future Work (Out of Scope)
+## Future Work (out of scope for the Base Profile)
 
 Additional profiles will be defined by extending the Base Profile with
-additional instructions and required runtime functions. The following features
-are explicitly out of scope for the Base Profile:
+additional instructions and required/supported runtime functions. The following
+features will not be supported in programs that are compliant with the Base
+Profile:
 
-- mid-circuit measurements
-- classical computations during quantum execution
-- use of local variables and command line parameters
-- dynamic qubit allocations
+- Branching based on measurement results: <br/>
+  For a Base Profile compliant program, the performed computations
+  (instructions) must not depend on measurement outcomes, i.e. the instruction
+  sequence is fully determined at compile time. See also the section on [open
+  questions](#open-questions) that are to be answered as part of this
+  workstream.
 
-Suitable profiles to support for one or more of these features will be defined
-as part of future workstreams.
+- Use of local variables and command line parameters: <br/>
+  For a Base Profile compliant program, all parameters must be known at compile
+  time, and measurement results are the only non-constant values in the program.
+  See also [open questions](#open-questions) around handling of measurement
+  results that are to be answered as part of this workstream.
+
+- Composite data types: <br/>
+  The use of composite data types such as [structure
+  types](https://llvm.org/doxygen/group__LLVMCCoreTypeStruct.html) including
+  [tuples](https://github.com/qir-alliance/qir-spec/blob/main/specification/v0.1/1_Data_Types.md#tuples-and-user-defined-types),
+  and [sequential
+  types](https://llvm.org/doxygen/group__LLVMCCoreTypeSequential.html) including
+  [arrays](https://github.com/qir-alliance/qir-spec/blob/main/specification/v0.1/1_Data_Types.md#arrays)
+  is not supported within a Base Profile compliant program. This also precludes
+  the use of such data structures for [callable
+  values](https://github.com/qir-alliance/qir-spec/blob/main/specification/v0.1/2_Callables.md);
+  i.e., the usage of subroutines as first class values is not supported within
+  the Base Profile, and the use of [function
+  types](https://llvm.org/doxygen/group__LLVMCCoreTypeFunction.html) is limited
+  to globally declared LLVM functions that may be called as part of program
+  execution.
+
+- Classical computations during quantum execution: <br/>
+  Execution of a Base Profile compliant quantum programs should not require
+  storing or processing classical values beyond storing and retrieving
+  measurement results. Constant values of simple data types, such as for example
+  integers or floating points, may be used as arguments in QIS calls if the
+  chosen QIS contains functions that make use of such types. A common example
+  are single-qubit rotations, that are supported directly by various QPUs and
+  require passing in a rotation angle as argument.
+
+- Dynamic qubit allocations and access: <br/>
+  Within the Base Profile, all qubit uses refer directly to a unique qubit id
+  (requires an update of the full specification as part of this workstream).
+  Runtime functions for qubit allocation/release are not available, and the lack
+  of support for local variables and composite data types prevents any qubit
+  aliasing. Prohibiting classical computations and branching based on
+  measurement results furthermore precludes any dynamic qubit access.
+
+Additional profiles to support one or more of these features will be defined as
+part of future workstreams.
 
 ## Working Group & Getting Involved
 
-Working group participants: <br/>
-Working group chair:
+Working group participants: TBD <br/>
+Working group chair: Bettina Heim
 
 If you would like to contribute to the workstream, please contact
 [qiralliance@mail.com](mailto:qiralliance@mail.com).
 
 ## Schedule
 
-Launch date: <br/>
-Estimated end date: <br/>
-Meeting schedule and/or channel(s) of communication:
+Launch date: February 2022 <br/>
+Estimated end date: end of March / early April 2022 <br/>
+Meeting schedule and/or channel(s) of communication: TBD
 
 ## Status & Discussions
 
-Current status: Workstream to be approved by steering committee
+Current status: This workstream has been approved by the steering committee.
 
-The work and status will be tracked in the form of a [GitHub
-issue](https://github.com/qir-alliance/qir-spec/issues) on the [specification
+The work and status is tracked in the form of a [GitHub
+issue](https://github.com/qir-alliance/qir-spec/issues/7) on the [specification
 repository](https://github.com/qir-alliance/qir-spec). We encourage comments,
 inputs, and discussions on that issue.
 
-The GitHub issue with be tagged appropriately after approval by the steering
-committee.
+## Open Questions (to be answered as part of the workstream)
 
-## Open Questions
+The following topics should be fleshed out as part of this workstream, and the
+decisions should be captured in an appropriate part of the specification:
 
-Should the profile allow to use constant values as arguments to quantum
-instructions? <br/>
-What are the rules for using constants as part of the program? <br/>
-Should any quantum instruction set be valid for use with the Base Profile?
+- Qubit (re-)use: <br/>
+  This workstream will define whether for a Base Profile compliant program
+  qubits may be used after measuring their state. The specification should also
+  capture what guarantees the backend should give around qubit use, such as,
+  e.g., whether qubits with a certain id will necessarily always be mapped to
+  the same device qubits, and whether qubits can be measured repeatedly. The
+  specification should also give recommendations for resetting the state of
+  qubits if necessary.
+
+- Measurements: <br/>
+  The Base Profile specification should define whether measurements may occur at
+  any point in the program or only at the end. How to store and retrieve
+  measurement results, as well as any related restrictions, will also be defined
+  as part of this workstream. This in particular also includes defining whether
+  any subset of qubits can be measured.
+
+- Base Profile compliant QIS: <br/>
+  Any restrictions and requirements for a QIS to be used in combination with a
+  Base Profile compliant program need to be clarified, such as, e.g., whether
+  the QIS may contain instruction that return values. The workstream should also
+  clarify whether a valid QIS is expected to be universal in the quantum sense,
+  and whether there should always exist a mapping from one QIS to another.
+
+- Dynamic linking and symbol resolution: <br/>
+  Related to the questions around how to define and specify a QIS,
+  considerations around the the linking stage should be captures. In particular,
+  the specification should give guidance about whether supporting libraries
+  and/or the QIS may be linked before or after compilation into a Base Profile,
+  as well as capture how to symbols are resolved during this stage.


### PR DESCRIPTION
This PR contains the SC meeting minutes from the February meeting. 
It also updates the Base Profile workstream definition per the SC discussion, and updates the org readme to reflect that the workstream has been approved (after approval of the edits via PR review here).

Rather than revising the requirements and/or out of scope section to capture the thoughts on dynamic linking and symbol resolution, I added a bullet point under the section on open questions that are to be answered as part of the workstream. This seemed appropriate, given that we will also need to clarify how to work with different qis as part of this workstream.