### PR TITLE
chore(ci): update actions for node24

### DIFF
--- a/.github/markdown-link-check-config.json
+++ b/.github/markdown-link-check-config.json
@@ -1,0 +1,6 @@
+{
+  "retryOn429": true,
+  "retryCount": 2,
+  "fallbackRetryDelay": "5s",
+  "aliveStatusCodes": [200, 206, 429]
+}

--- a/.github/workflows/link_and_spell_check.yml
+++ b/.github/workflows/link_and_spell_check.yml
@@ -46,4 +46,3 @@ jobs:
         # positives with terminology in quantum computing.
         strict: false
         incremental_files_only: true
-        config: 'utils/spelling_allowlist.json'

--- a/.github/workflows/link_and_spell_check.yml
+++ b/.github/workflows/link_and_spell_check.yml
@@ -34,6 +34,7 @@ jobs:
       # cspell:words gaurav
       uses: gaurav-nelson/github-action-markdown-link-check@v1
       with:
+        config-file: '.github/markdown-link-check-config.json'
         use-verbose-mode: 'yes'
       if: ${{ success() || failure() }}
     - name: "Check spelling in changed files"

--- a/.github/workflows/link_and_spell_check.yml
+++ b/.github/workflows/link_and_spell_check.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     name: "Check spelling, linting and links"
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6
     - run: |
         wget https://github.com/qir-alliance/.github/archive/refs/heads/main.zip -O clone.zip &&
         unzip clone.zip && mv .github-main out && rm clone.zip &&
@@ -39,7 +39,7 @@ jobs:
       if: ${{ success() || failure() }}
     - name: "Check spelling in changed files"
       # cspell:words streetsidesoftware
-      uses: streetsidesoftware/cspell-action@v1.2.4
+      uses: streetsidesoftware/cspell-action@v8
       with:
         inline: warning
         # Only warn on spelling errors, since there's likely a lot of false

--- a/minutes/sc-meeting-2022-08.md
+++ b/minutes/sc-meeting-2022-08.md
@@ -69,6 +69,6 @@ a topic of the next QIR community call.
 good platform for IR inspection; Nvidia will bring tooling and a new community
 to QIR.
 - References
-  - [Base Profile Specification](https://github.com/qir-alliance/qir-spec/blob/main/specification/under_development/profiles/Base_Profile.md)
+  - [Base Profile Specification](https://github.com/qir-alliance/qir-spec/blob/1.0/specification/profiles/Base_Profile.md)
   - [Runtime Initialization Workstream](https://github.com/amccaskey/.github/blob/main/workstreams/Runtime_Init_Finalize_EntryPoint_Workstream.md)
   - [QIR Alliance Project Charter](https://github.com/qir-alliance/.github/blob/main/Project_Organization.md)

--- a/workflow-templates/link_and_spell_check.yml
+++ b/workflow-templates/link_and_spell_check.yml
@@ -46,4 +46,6 @@ jobs:
         # positives with terminology in quantum computing.
         strict: false
         incremental_files_only: true
-        config: 'utils/spelling_allowlist.json'
+        # To allowlist project-specific terms in a consuming repo, add a valid
+        # CSpell config file such as cspell.json and uncomment:
+        # config: 'cspell.json'

--- a/workflow-templates/link_and_spell_check.yml
+++ b/workflow-templates/link_and_spell_check.yml
@@ -34,6 +34,7 @@ jobs:
       # cspell:words gaurav
       uses: gaurav-nelson/github-action-markdown-link-check@v1
       with:
+        config-file: 'utils/markdown-link-check-config.json'
         use-verbose-mode: 'yes'
       if: ${{ success() || failure() }}
     - name: "Check spelling in changed files"

--- a/workflow-templates/link_and_spell_check.yml
+++ b/workflow-templates/link_and_spell_check.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     name: "Check spelling, linting and links"
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6
     - run: |
         wget https://github.com/qir-alliance/.github/archive/refs/heads/main.zip -O clone.zip &&
         unzip clone.zip && mv .github-main out && rm clone.zip &&
@@ -39,7 +39,7 @@ jobs:
       if: ${{ success() || failure() }}
     - name: "Check spelling in changed files"
       # cspell:words streetsidesoftware
-      uses: streetsidesoftware/cspell-action@v1.2.4
+      uses: streetsidesoftware/cspell-action@v8
       with:
         inline: warning
         # Only warn on spelling errors, since there's likely a lot of false

--- a/workflow-templates/utils/markdown-link-check-config.json
+++ b/workflow-templates/utils/markdown-link-check-config.json
@@ -1,0 +1,6 @@
+{
+  "retryOn429": true,
+  "retryCount": 2,
+  "fallbackRetryDelay": "5s",
+  "aliveStatusCodes": [200, 206, 429]
+}

--- a/workflow-templates/utils/md_lint_config.yml
+++ b/workflow-templates/utils/md_lint_config.yml
@@ -1,6 +1,6 @@
 # For more info on markdown lint configurations, see also
 # https://github.com/DavidAnson/markdownlint/blob/main/schema/.markdownlint.yaml
-# https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md
+# https://github.com/markdownlint/markdownlint/blob/main/docs/RULES.md
 
 default: true
 line-length:

--- a/workstreams/Adaptive_Profile_Workstream.md
+++ b/workstreams/Adaptive_Profile_Workstream.md
@@ -60,7 +60,7 @@ computations with certain data types and non-trivial control flow structures. It
 will limit expressiveness to guarantee that the program always terminates (no
 unbounded loops or recursions). This specification will replace what is
 currently drafted as [Profile
-B](https://github.com/qir-alliance/qir-spec/blob/main/specification/v0.1/7_Profiles.md#profile-a-basic-quantum-functionality)
+B](https://github.com/qir-alliance/qir-spec/blob/1.0/specification/legacy/7_Profiles.md#profile-a-basic-quantum-functionality)
 on the [specification repository](https://github.com/qir-alliance/qir-spec).
 
 Like the Base Profile, the Adaptive Profile should not rely on any particular
@@ -70,7 +70,7 @@ instruction set. The profile and the quantum instruction set (QIS) selection
 together determine how the program IR should be represented.
 
 A similar specification for the Base Profile can be found
-[here](https://github.com/qir-alliance/qir-spec/blob/main/specification/under_development/profiles/Base_Profile.md).
+[here](https://github.com/qir-alliance/qir-spec/blob/1.0/specification/profiles/Base_Profile.md).
 The specification of the Adaptive Profile should follow a similar outline for
 the sake of consistency and comprehensiveness of the specification.
 
@@ -82,13 +82,13 @@ the Adaptive Profile:
 - Composite data types: <br/>
   The use of composite data types such as [structure
   types](https://llvm.org/doxygen/group__LLVMCCoreTypeStruct.html) including
-  [tuples](https://github.com/qir-alliance/qir-spec/blob/main/specification/v0.1/1_Data_Types.md#tuples-and-user-defined-types),
+  [tuples](https://github.com/qir-alliance/qir-spec/blob/1.0/specification/legacy/1_Data_Types.md#tuples-and-user-defined-types),
   and [sequential
   types](https://llvm.org/doxygen/group__LLVMCCoreTypeSequential.html) including
-  [arrays](https://github.com/qir-alliance/qir-spec/blob/main/specification/v0.1/1_Data_Types.md#arrays)
+  [arrays](https://github.com/qir-alliance/qir-spec/blob/1.0/specification/legacy/1_Data_Types.md#arrays)
   is not supported within an Adaptive Profile. This also precludes the use of
   such data structures for [callable
-  values](https://github.com/qir-alliance/qir-spec/blob/main/specification/v0.1/2_Callables.md);
+  values](https://github.com/qir-alliance/qir-spec/blob/1.0/specification/legacy/2_Callables.md);
   i.e., the usage of subroutines as first class values is not supported within
   the Adaptive Profile, and the use of [function
   types](https://llvm.org/doxygen/group__LLVMCCoreTypeFunction.html) is limited

--- a/workstreams/Adaptive_Profile_Workstream.md
+++ b/workstreams/Adaptive_Profile_Workstream.md
@@ -85,7 +85,6 @@ the Adaptive Profile:
   [tuples](https://github.com/qir-alliance/qir-spec/blob/1.0/specification/legacy/1_Data_Types.md#tuples-and-user-defined-types),
   and [sequential
   types](https://llvm.org/doxygen/group__LLVMCCoreTypeSequential.html) including
-  <!-- markdown-link-check-disable-next-line -->
   [arrays](https://github.com/qir-alliance/qir-spec/blob/1.0/specification/legacy/1_Data_Types.md#arrays)
   is not supported within an Adaptive Profile. This also precludes the use of
   such data structures for [callable

--- a/workstreams/Adaptive_Profile_Workstream.md
+++ b/workstreams/Adaptive_Profile_Workstream.md
@@ -85,6 +85,7 @@ the Adaptive Profile:
   [tuples](https://github.com/qir-alliance/qir-spec/blob/1.0/specification/legacy/1_Data_Types.md#tuples-and-user-defined-types),
   and [sequential
   types](https://llvm.org/doxygen/group__LLVMCCoreTypeSequential.html) including
+  <!-- markdown-link-check-disable-next-line -->
   [arrays](https://github.com/qir-alliance/qir-spec/blob/1.0/specification/legacy/1_Data_Types.md#arrays)
   is not supported within an Adaptive Profile. This also precludes the use of
   such data structures for [callable

--- a/workstreams/Base_Profile_Workstream.md
+++ b/workstreams/Base_Profile_Workstream.md
@@ -49,7 +49,7 @@ the requirements outlined [above](#requirements). The intent is for the Base
 Profile to permit expressing quantum programs that contain no control flow or
 classical computations during execution. This specification will replace what is
 currently drafted as [Profile
-A](https://github.com/qir-alliance/qir-spec/blob/main/specification/v0.1/7_Profiles.md#profile-a-basic-quantum-functionality)
+A](https://github.com/qir-alliance/qir-spec/blob/1.0/specification/legacy/7_Profiles.md#profile-a-basic-quantum-functionality)
 on the [specification repository](https://github.com/qir-alliance/qir-spec).
 
 In addition to the Base Profile itself, one or more quantum instruction set(s)
@@ -67,7 +67,7 @@ specification that contains guidance for defining and documenting addition
 quantum instruction sets going forward.
 
 A template for a specification definition can be found
-[here](https://github.com/CommunitySpecification/1.0/blob/master/7._CS_Template.md).
+[here](https://github.com/CommunitySpecification/1.0/blob/main/7._CS_Template.md).
 This may serve as inspiration but it is not required to follow the template
 precisely.
 
@@ -96,13 +96,13 @@ Profile:
 - Composite data types: <br/>
   The use of composite data types such as [structure
   types](https://llvm.org/doxygen/group__LLVMCCoreTypeStruct.html) including
-  [tuples](https://github.com/qir-alliance/qir-spec/blob/main/specification/v0.1/1_Data_Types.md#tuples-and-user-defined-types),
+  [tuples](https://github.com/qir-alliance/qir-spec/blob/1.0/specification/legacy/1_Data_Types.md#tuples-and-user-defined-types),
   and [sequential
   types](https://llvm.org/doxygen/group__LLVMCCoreTypeSequential.html) including
-  [arrays](https://github.com/qir-alliance/qir-spec/blob/main/specification/v0.1/1_Data_Types.md#arrays)
+  [arrays](https://github.com/qir-alliance/qir-spec/blob/1.0/specification/legacy/1_Data_Types.md#arrays)
   is not supported within a Base Profile compliant program. This also precludes
   the use of such data structures for [callable
-  values](https://github.com/qir-alliance/qir-spec/blob/main/specification/v0.1/2_Callables.md);
+  values](https://github.com/qir-alliance/qir-spec/blob/1.0/specification/legacy/2_Callables.md);
   i.e., the usage of subroutines as first class values is not supported within
   the Base Profile, and the use of [function
   types](https://llvm.org/doxygen/group__LLVMCCoreTypeFunction.html) is limited

--- a/workstreams/Base_Profile_Workstream.md
+++ b/workstreams/Base_Profile_Workstream.md
@@ -67,7 +67,6 @@ specification that contains guidance for defining and documenting addition
 quantum instruction sets going forward.
 
 A template for a specification definition can be found
-<!-- markdown-link-check-disable-next-line -->
 [here](https://github.com/CommunitySpecification/1.0/blob/main/7._CS_Template.md).
 This may serve as inspiration but it is not required to follow the template
 precisely.
@@ -100,7 +99,6 @@ Profile:
   [tuples](https://github.com/qir-alliance/qir-spec/blob/1.0/specification/legacy/1_Data_Types.md#tuples-and-user-defined-types),
   and [sequential
   types](https://llvm.org/doxygen/group__LLVMCCoreTypeSequential.html) including
-  <!-- markdown-link-check-disable-next-line -->
   [arrays](https://github.com/qir-alliance/qir-spec/blob/1.0/specification/legacy/1_Data_Types.md#arrays)
   is not supported within a Base Profile compliant program. This also precludes
   the use of such data structures for [callable

--- a/workstreams/Base_Profile_Workstream.md
+++ b/workstreams/Base_Profile_Workstream.md
@@ -67,6 +67,7 @@ specification that contains guidance for defining and documenting addition
 quantum instruction sets going forward.
 
 A template for a specification definition can be found
+<!-- markdown-link-check-disable-next-line -->
 [here](https://github.com/CommunitySpecification/1.0/blob/main/7._CS_Template.md).
 This may serve as inspiration but it is not required to follow the template
 precisely.
@@ -99,6 +100,7 @@ Profile:
   [tuples](https://github.com/qir-alliance/qir-spec/blob/1.0/specification/legacy/1_Data_Types.md#tuples-and-user-defined-types),
   and [sequential
   types](https://llvm.org/doxygen/group__LLVMCCoreTypeSequential.html) including
+  <!-- markdown-link-check-disable-next-line -->
   [arrays](https://github.com/qir-alliance/qir-spec/blob/1.0/specification/legacy/1_Data_Types.md#arrays)
   is not supported within a Base Profile compliant program. This also precludes
   the use of such data structures for [callable


### PR DESCRIPTION
## Summary
- update `actions/checkout` in the link and spell check workflow and template to `v6`
- update `streetsidesoftware/cspell-action` in the same workflow and template to `v8`
- retain the markdown link check `429` handling already present on this branch

## Notes
- this addresses the GitHub Actions Node 20 runtime deprecation warning for `actions/checkout` and `cspell-action`
- third-party markdown actions still emit npm deprecation warnings during execution and are unchanged here